### PR TITLE
Add datasets D4, D5 and models M4, M5

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -378,7 +378,7 @@ CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 3 -tr nnUNetTrainer_2000epo
 CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 4 -tr nnUNetTrainer_2000epochs
 ```
 
-#### iv) Reproduce D5, M5
+#### v) Reproduce D5, M5
 
 The dataset D5 composed of 36 images with 31 for train.
 I have trained 5 folds of a nnUNet 3d_fullres model for 2000 epochs: 
@@ -391,6 +391,8 @@ CUDA_VISIBLE_DEVICES=3 nnUNetv2_train 012 3d_fullres 2 -tr nnUNetTrainer_2000epo
 CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 012 3d_fullres 3 -tr nnUNetTrainer_2000epochs
 CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 012 3d_fullres 4 -tr nnUNetTrainer_2000epochs
 ```
+
+For resulting Dice, see https://github.com/ivadomed/model-spinal-rootlets/pull/23#issuecomment-1843240432
 
 #Link to dataset D1b, D2, D3 already done, make one release per dataset ?
 

--- a/training/README.md
+++ b/training/README.md
@@ -63,6 +63,7 @@ will be numbered as D1, D2, etc., and the models as M1, M2, etc.
 | D1b (nnUNet 006)  | 18                                     |      22.9       |   1.21   | Binary         | Prediction + Manual review |         0.52~0.6         | [D1b.tsv](dataset_creation/D1b.tsv) |
 |  D2 (nnUNet 007)  | 36 (20 from D0b + D1b) + 2 test images |      26.2       |   5.2    | Binary         | Prediction + Manual review |        0.65~0.75         | [D2.tsv](dataset_creation/D2.tsv)   |
 |  D3 (nnUNet 008-9) | 31 + 2 test images                     |      26.5       |   5.5    | Level specific | Value modification         |         0.4~0.6          | [D3.tsv](dataset_creation/D3.tsv)   |
+|  D4 (nnUNet 011) | 33 + 5 test images                     |             |       | Level specific | Prediction + Manual review         |                   | [D4.tsv](dataset_creation/D4.tsv)   |
 
 <details>
 <summary>Details</summary>
@@ -127,6 +128,16 @@ yielded a dice score also ranging between 0.4 and 0.6. However, it exhibited mor
 exceeding 0.5 compared to the first training conducted with 1000 epochs.
 
 > Refer to [issue#8 part 3)](https://github.com/ivadomed/model-spinal-rootlets/issues/8).
+
+#### D4)
+
+Five images used for [inter-rater variability](https://github.com/ivadomed/model-spinal-rootlets/issues/17) 
+(`sub-007_ses-headNormal_T2w.nii.gz`, `sub-010_ses-headUp_T2w.nii.gz`, `sub-amu02_T2w.nii.gz`, `sub-barcelona01_T2w.nii.gz`, 
+`sub-brnoUhb03_T2w.nii.gz`) were moved from the training dataset to the test dataset. 
+The D3 model was applied to five new images from the spine-generic dataset (`sub-mgh01_T2w.nii.gz`, `sub-mgh02_T2w.nii.gz`, 
+`sub-stanford02_T2w.nii.gz`, `sub-stanford05_T2w.nii.gz`, `sub-ucdavis03_T2w.nii.gz`), the images were QCed, manually 
+corrected and added to the training dataset. 
+The D4 training dataset comprises 33 images, the test dataset comprises 5 images. For details, see [D4.tsv](dataset_creation/D4.tsv).
 
 </details>
 
@@ -330,13 +341,28 @@ sub-011_ses-headUp_T2w.nii.gz
 
 </details>
 
-This dataset D3 composed of 33 images with 31 for train .
-I have trained 4 folds of a nnUNet 3d_fullres model for 2000
-epochs `CUDA_VISIBLE_DEVICES=XXX nnUNetv2_train DATASETID -tr nnUNetTrainer_2000epochs -f 0`
+The dataset D3 composed of 33 images with 31 for train.
+I have trained 5 folds of a nnUNet 3d_fullres model for 2000 epochs:
+
+```
+CUDA_VISIBLE_DEVICES=XXX nnUNetv2_train DATASETID -tr nnUNetTrainer_2000epochs -f 0
+```
 
 nnUNet Dice score from `progress.png` was between 0.4 and 0.6.
 
-#### iv) Get our dataset
+#### iv) Reproduce D4, M4
+
+The dataset D4 composed of 38 images with 33 for train.
+I have trained 5 folds of a nnUNet 3d_fullres model for 2000 epochs: 
+
+```
+nnUNetv2_plan_and_preprocess -d 011 --verify_dataset_integrity -c 3d_fullres
+CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 0 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 1 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=3 nnUNetv2_train 011 3d_fullres 2 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 3 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 4 -tr nnUNetTrainer_2000epochs
+```
 
 #Link to dataset D1b, D2, D3 already done, make one release per dataset ?
 

--- a/training/README.md
+++ b/training/README.md
@@ -68,6 +68,7 @@ will be numbered as D1, D2, etc., and the models as M1, M2, etc.
 |  D2 (nnUNet 007)  | 36 (20 from D0b + D1b) + 2 test images |      26.2       |   5.2    | Binary         | Prediction + Manual review |        0.65~0.75         | [D2.tsv](dataset_creation/D2.tsv)   |
 |  D3 (nnUNet 008-9) | 31 + 2 test images                     |      26.5       |   5.5    | Level specific | Value modification         |         0.4~0.6          | [D3.tsv](dataset_creation/D3.tsv)   |
 |  D4 (nnUNet 011) | 33 + 5 test images                     |             |       | Level specific | Prediction + Manual review         |                   | [D4.tsv](dataset_creation/D4.tsv)   |
+|  D5 (nnUNet 012) | 31 + 5 test images                     |             |       | Level specific | Prediction + Manual review         |                   | [D5.tsv](dataset_creation/D5.tsv)   |
 
 <details>
 <summary>Details</summary>
@@ -142,6 +143,15 @@ The D3 model was applied to five new randomly chosen images from the spine-gener
 `sub-stanford02_T2w.nii.gz`, `sub-stanford05_T2w.nii.gz`, `sub-ucdavis03_T2w.nii.gz`), the images were QCed, manually 
 corrected and added to the training dataset. 
 The D4 training dataset comprises 33 images, and the test dataset comprises 5 images. For details, see [D4.tsv](dataset_creation/D4.tsv).
+
+#### D5)
+
+During M4 training using D4 dataset, I noticed `0` and `nan` dice for some levels --> I checked all the D4 labels and 
+found that some labels were wrong (some labels contained values `1` (probably legacy from binary levels) and some levels 
+were mislabeled) --> I corrected the labels. Also, I made sure that the labels contains only levels 2 to 8 (we do not 
+have enough subjects with levels >9). Also, I removed `sub-004_ses-headUp` (difficult to label) and `sub-008_ses-headUp` 
+(wrong FOV covering only C1-C4). The final dataset is called D5.
+The D5 training dataset comprises 31 images, and the test dataset comprises 5 images. For details, see [D5.tsv](dataset_creation/D5.tsv).
 
 </details>
 
@@ -366,6 +376,20 @@ CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 1 -tr nnUNetTrainer_2000epo
 CUDA_VISIBLE_DEVICES=3 nnUNetv2_train 011 3d_fullres 2 -tr nnUNetTrainer_2000epochs
 CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 3 -tr nnUNetTrainer_2000epochs
 CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 4 -tr nnUNetTrainer_2000epochs
+```
+
+#### iv) Reproduce D5, M5
+
+The dataset D5 composed of 36 images with 31 for train.
+I have trained 5 folds of a nnUNet 3d_fullres model for 2000 epochs: 
+
+```
+nnUNetv2_plan_and_preprocess -d 012 --verify_dataset_integrity -c 3d_fullres
+CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 012 3d_fullres 0 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 012 3d_fullres 1 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=3 nnUNetv2_train 012 3d_fullres 2 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 012 3d_fullres 3 -tr nnUNetTrainer_2000epochs
+CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 012 3d_fullres 4 -tr nnUNetTrainer_2000epochs
 ```
 
 #Link to dataset D1b, D2, D3 already done, make one release per dataset ?

--- a/training/README.md
+++ b/training/README.md
@@ -1,5 +1,9 @@
 # Spinal Nerve Rootlets Segmentation on T2w Images
 
+## 0) Dependencies
+
+- nnUNetV2 - GPU installation for model training: [here](https://github.com/ivadomed/utilities/blob/main/quick_start_guides/nnU-Net_quick_start_guide.md#installation)
+
 ## 1) Project Overview
 
 The goal of this project is to develop a deep learning (DL)-based method to segment and locate the spinal nerve

--- a/training/README.md
+++ b/training/README.md
@@ -134,10 +134,10 @@ exceeding 0.5 compared to the first training conducted with 1000 epochs.
 Five images used for [inter-rater variability](https://github.com/ivadomed/model-spinal-rootlets/issues/17) 
 (`sub-007_ses-headNormal_T2w.nii.gz`, `sub-010_ses-headUp_T2w.nii.gz`, `sub-amu02_T2w.nii.gz`, `sub-barcelona01_T2w.nii.gz`, 
 `sub-brnoUhb03_T2w.nii.gz`) were moved from the training dataset to the test dataset. 
-The D3 model was applied to five new images from the spine-generic dataset (`sub-mgh01_T2w.nii.gz`, `sub-mgh02_T2w.nii.gz`, 
+The D3 model was applied to five new randomly chosen images from the spine-generic dataset (`sub-mgh01_T2w.nii.gz`, `sub-mgh02_T2w.nii.gz`, 
 `sub-stanford02_T2w.nii.gz`, `sub-stanford05_T2w.nii.gz`, `sub-ucdavis03_T2w.nii.gz`), the images were QCed, manually 
 corrected and added to the training dataset. 
-The D4 training dataset comprises 33 images, the test dataset comprises 5 images. For details, see [D4.tsv](dataset_creation/D4.tsv).
+The D4 training dataset comprises 33 images, and the test dataset comprises 5 images. For details, see [D4.tsv](dataset_creation/D4.tsv).
 
 </details>
 

--- a/training/check_voxels.py
+++ b/training/check_voxels.py
@@ -1,0 +1,47 @@
+"""
+This script opens a NIfTI image, finds the coordinates of voxels with a specified value,
+and prints the voxel coordinates along with the maximum and minimum values in the image.
+
+Usage:
+python script.py <nii_image_path>
+
+Jan Valosek
+"""
+
+import nibabel as nib
+import numpy as np
+
+def find_coordinates_with_value(image_path, target_value=1):
+    # Load NIfTI image
+    img = nib.load(image_path)
+
+    # Get image data as a NumPy array
+    data = img.get_fdata()
+
+    # Find voxel coordinates with the specified value
+    coordinates = np.argwhere(data == target_value)
+
+    # Get max and min values in the image
+    max_value = np.max(data)
+    min_value = np.min(data)
+
+    return coordinates, max_value, min_value
+
+if __name__ == "__main__":
+    import sys
+
+    # Check if the input argument is provided
+    if len(sys.argv) != 2:
+        print("Usage: python script.py <nii_image_path>")
+        sys.exit(1)
+
+    # Get the NIfTI image path from the command line arguments
+    nii_image_path = sys.argv[1]
+
+    # Find coordinates with value 1 and max/min values in the NIfTI image
+    voxel_coordinates, max_value, min_value = find_coordinates_with_value(nii_image_path)
+
+    # Print the result
+    print(f"Voxel coordinates with value 1 in {nii_image_path}:\n{voxel_coordinates}")
+    print(f"Max value in the image: {max_value}")
+    print(f"Min value in the image: {min_value}")

--- a/training/dataset_creation/D4.tsv
+++ b/training/dataset_creation/D4.tsv
@@ -1,0 +1,39 @@
+file_name	folder	sex	age	resolution (mm)	neck_flexion	height	weight	date_of_scan	institution_id	institution	manufacturer	manufacturers_model_name	receive_coil_name	software_versions	researcher	pathology	notes
+sub-amu01_T2w.nii.gz	train	M	28	0.8	N	176.0	70.0	12/02/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC
+sub-amu05_T2w.nii.gz	train	F	39	0.8	N	175.0	66.0	01/03/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC	disc protrusion C4/5/6 and mild kyphosis
+sub-balgrist01_T2w.nii.gz	train	F	31	0.8	N	158.0	60.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	Mild kyphosis
+sub-balgrist02_T2w.nii.gz	train	F	22	0.8	N	170.0	72.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	Mild kyphosis
+sub-balgrist03_T2w.nii.gz	train	F	23	0.8	N	175.0	85.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	disc protrusion C3/4 and mild kyphosis
+sub-balgrist04_T2w.nii.gz	train	M	28	0.8	N	195.0	90.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	
+sub-balgrist06_T2w.nii.gz	train	M	23	0.8	N	170.0	64.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	visualised spinal canal C5-Th1
+sub-barcelona02_T2w.nii.gz	train	M	38	0.8	N	190.0	95.0	23/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4-6 disc protrusions
+sub-barcelona03_T2w.nii.gz	train	M	39	0.8	N	185.0	85.0	23/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4/5 disc hernia
+sub-barcelona06_T2w.nii.gz	train	F	25	0.8	N	170.0	55.0	30/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	HC	disc protrusions C4-7 and Th4-6
+sub-brnoUhb01_T2w.nii.gz	train	M	21	0.8	N	180.0	90.0	13/02/2019	brnoUhb	The University Hospital Brno, Department of Radiology and Nuclear Medicine, Czech Republic	GE	Signa-PETMR	MP24	Marek Dostal, Milo Kekovsk	HC	disc protrusions C4-7
+sub-cardiff02_T2w.nii.gz	train	F	34	0.8	N	172.0	54.0	05/03/2019	cardiff	CUBRIC, Cardiff University, Wales, UK	Siemens	Prisma	HeadNeck_64	VE11C	G. Tackley, S. Kusmia, R. Wise	HC	disc protrusion Th2/3
+sub-cardiff04_T2w.nii.gz	train	F	31	0.8	N	170.0	58.0	12/03/2019	cardiff	CUBRIC, Cardiff University, Wales, UK	Siemens	Prisma	HeadNeck_64	VE11C	G. Tackley, S. Kusmia, R. Wise	HC	disc protrusion C3-7 and Th2-4
+sub-cmrra02_T2w.nii.gz	train	M	27	0.8	N	188.0	91.0	01/03/2019	cmrra	University of Minnesota	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	R. Labounek, J. Joers, C. Nguyen, I. Nestrasil, C. Lenglet, P-G. Henry	HC	disc protrusions C4-7
+sub-cmrra04_T2w.nii.gz	train	F	22	0.8	N	163.0	54.0	18/03/2019	cmrra	University of Minnesota	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	R. Labounek, J. Joers, C. Nguyen, I. Nestrasil, C. Lenglet, P-G. Henry	HC	disc protrusion and kyphosis at C3/4
+sub-geneva01_T2w.nii.gz	train	M	29	0.8	N	189.0	69.0	21/02/2019	geneva	Campus Biotech Geneva	Siemens	Prisma	64ch+spine	VE11C	K. Kinany, L. Mattera	HC	Chondrosis and disc protrusions C3-7
+sub-mgh01_T2w.nii.gz	train	F	28	0.8	N	173	73	2019-01-01	mgh	Massachusetts General Hospital	Siemens	Skyra	64ch+spine	VE11C	R. L. Barry	HC	disc protrusions C3-6
+sub-mgh02_T2w.nii.gz	train	F	33	0.8	N	155	41	2019-01-01	mgh	Massachusetts General Hospital	Siemens	Skyra	64ch+spine	VE11C	R. L. Barry	HC	disc protrusion C5/6
+sub-stanford02_T2w.nii.gz	train	F	39	0.8	N	163	54	2018-02-22	stanford	Stanford University	GE	MR750	16ch neurovascular	DV26.0_R01	C. S. Law, K. A. Weber II, S. Mackey, K. R. Epperson, K. S Epperson	HC	n/a
+sub-stanford05_T2w.nii.gz	train	M	19	0.8	N	178	59	2018-02-24	stanford	Stanford University	GE	MR750	16ch neurovascular	DV26.0_R01	C. S. Law, K. A. Weber II, S. Mackey, K. R. Epperson, K. S Epperson	HC	Disc protrusion C3/4
+sub-ucdavis03_T2w.nii.gz	train	M	41	0.8	N	179	82	n/a	ucdavis	UC Davis Health, California, US	Siemens	Vida	HeadNeck_64	syngo MR XA20	Allan R. Martin	HC	Mild disc protrusions C3-7
+sub-brnoUhb03_T2w.nii.gz	test	F	26	0.8	N	163.0	56.0	13/02/2019	brnoUhb	The University Hospital Brno, Department of Radiology and Nuclear Medicine, Czech Republic	GE	Signa-PETMR	MP24	Marek Dostal, Milo Kekovsk	HC	disc protrusions C4-7
+sub-amu02_T2w.nii.gz	test	M	28	0.8	N	183.0	67.0	13/02/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC	disc protrusion Th2/3, visualised central canal
+sub-barcelona01_T2w.nii.gz	test	M	36	0.8	N	170.0	70.0	16/10/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4/5 disc protrusion
+sub-002_ses-headNormal_T2w.nii.gz	train	F	22	0.6	N
+sub-003_ses-headNormal_T2w.nii.gz	train	M	22	0.6	N
+sub-003_ses-headUp_T2w.nii.gz	train	M	22	0.6	U
+sub-004_ses-headNormal_T2w.nii.gz	train	F	23	0.6	N
+sub-004_ses-headUp_T2w.nii.gz	train	F	23	0.6	U
+sub-005_ses-headNormal_T2w.nii.gz	train	M	22	0.6	N
+sub-005_ses-headUp_T2w.nii.gz	train	M	22	0.6	U
+sub-007_ses-headUp_T2w.nii.gz	train	M	23	0.6	U
+sub-008_ses-headUp_T2w.nii.gz	train	M	26	0.6	U
+sub-010_ses-headNormal_T2w.nii.gz	train	M	23	0.6	N
+sub-011_ses-headNormal_T2w.nii.gz	train	M	23	0.6	N
+sub-011_ses-headUp_T2w.nii.gz	train	M	23	0.6	U
+sub-007_ses-headNormal_T2w.nii.gz	test	M	23	0.6	N
+sub-010_ses-headUp_T2w.nii.gz	test	M	23	0.6	U

--- a/training/dataset_creation/D5.tsv
+++ b/training/dataset_creation/D5.tsv
@@ -1,0 +1,37 @@
+file_name	folder	sex	age	resolution (mm)	neck_flexion	height	weight	date_of_scan	institution_id	institution	manufacturer	manufacturers_model_name	receive_coil_name	software_versions	researcher	pathology	notes
+sub-amu01_T2w.nii.gz	train	M	28	0.8	N	176.0	70.0	12/02/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC
+sub-amu05_T2w.nii.gz	train	F	39	0.8	N	175.0	66.0	01/03/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC	disc protrusion C4/5/6 and mild kyphosis
+sub-balgrist01_T2w.nii.gz	train	F	31	0.8	N	158.0	60.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	Mild kyphosis
+sub-balgrist02_T2w.nii.gz	train	F	22	0.8	N	170.0	72.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	Mild kyphosis
+sub-balgrist03_T2w.nii.gz	train	F	23	0.8	N	175.0	85.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	disc protrusion C3/4 and mild kyphosis
+sub-balgrist04_T2w.nii.gz	train	M	28	0.8	N	195.0	90.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	
+sub-balgrist06_T2w.nii.gz	train	M	23	0.8	N	170.0	64.0	balgrist	Spinal Cord Injury Center University Balgrist Clinic	Siemens	Prisma	HeadNeck_64	VE11C	M. Seif, P. Freund	HC	visualised spinal canal C5-Th1
+sub-barcelona02_T2w.nii.gz	train	M	38	0.8	N	190.0	95.0	23/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4-6 disc protrusions
+sub-barcelona03_T2w.nii.gz	train	M	39	0.8	N	185.0	85.0	23/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4/5 disc hernia
+sub-barcelona06_T2w.nii.gz	train	F	25	0.8	N	170.0	55.0	30/11/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	HC	disc protrusions C4-7 and Th4-6
+sub-brnoUhb01_T2w.nii.gz	train	M	21	0.8	N	180.0	90.0	13/02/2019	brnoUhb	The University Hospital Brno, Department of Radiology and Nuclear Medicine, Czech Republic	GE	Signa-PETMR	MP24	Marek Dostal, Milo Kekovsk	HC	disc protrusions C4-7
+sub-cardiff02_T2w.nii.gz	train	F	34	0.8	N	172.0	54.0	05/03/2019	cardiff	CUBRIC, Cardiff University, Wales, UK	Siemens	Prisma	HeadNeck_64	VE11C	G. Tackley, S. Kusmia, R. Wise	HC	disc protrusion Th2/3
+sub-cardiff04_T2w.nii.gz	train	F	31	0.8	N	170.0	58.0	12/03/2019	cardiff	CUBRIC, Cardiff University, Wales, UK	Siemens	Prisma	HeadNeck_64	VE11C	G. Tackley, S. Kusmia, R. Wise	HC	disc protrusion C3-7 and Th2-4
+sub-cmrra02_T2w.nii.gz	train	M	27	0.8	N	188.0	91.0	01/03/2019	cmrra	University of Minnesota	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	R. Labounek, J. Joers, C. Nguyen, I. Nestrasil, C. Lenglet, P-G. Henry	HC	disc protrusions C4-7
+sub-cmrra04_T2w.nii.gz	train	F	22	0.8	N	163.0	54.0	18/03/2019	cmrra	University of Minnesota	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	R. Labounek, J. Joers, C. Nguyen, I. Nestrasil, C. Lenglet, P-G. Henry	HC	disc protrusion and kyphosis at C3/4
+sub-geneva01_T2w.nii.gz	train	M	29	0.8	N	189.0	69.0	21/02/2019	geneva	Campus Biotech Geneva	Siemens	Prisma	64ch+spine	VE11C	K. Kinany, L. Mattera	HC	Chondrosis and disc protrusions C3-7
+sub-mgh01_T2w.nii.gz	train	F	28	0.8	N	173	73	2019-01-01	mgh	Massachusetts General Hospital	Siemens	Skyra	64ch+spine	VE11C	R. L. Barry	HC	disc protrusions C3-6
+sub-mgh02_T2w.nii.gz	train	F	33	0.8	N	155	41	2019-01-01	mgh	Massachusetts General Hospital	Siemens	Skyra	64ch+spine	VE11C	R. L. Barry	HC	disc protrusion C5/6
+sub-stanford02_T2w.nii.gz	train	F	39	0.8	N	163	54	2018-02-22	stanford	Stanford University	GE	MR750	16ch neurovascular	DV26.0_R01	C. S. Law, K. A. Weber II, S. Mackey, K. R. Epperson, K. S Epperson	HC	n/a
+sub-stanford05_T2w.nii.gz	train	M	19	0.8	N	178	59	2018-02-24	stanford	Stanford University	GE	MR750	16ch neurovascular	DV26.0_R01	C. S. Law, K. A. Weber II, S. Mackey, K. R. Epperson, K. S Epperson	HC	Disc protrusion C3/4
+sub-ucdavis03_T2w.nii.gz	train	M	41	0.8	N	179	82	n/a	ucdavis	UC Davis Health, California, US	Siemens	Vida	HeadNeck_64	syngo MR XA20	Allan R. Martin	HC	Mild disc protrusions C3-7
+sub-brnoUhb03_T2w.nii.gz	test	F	26	0.8	N	163.0	56.0	13/02/2019	brnoUhb	The University Hospital Brno, Department of Radiology and Nuclear Medicine, Czech Republic	GE	Signa-PETMR	MP24	Marek Dostal, Milo Kekovsk	HC	disc protrusions C4-7
+sub-amu02_T2w.nii.gz	test	M	28	0.8	N	183.0	67.0	13/02/2019	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot	HC	disc protrusion Th2/3, visualised central canal
+sub-barcelona01_T2w.nii.gz	test	M	36	0.8	N	170.0	70.0	16/10/2018	barcelona	Advanced Imaging in Neuroimmunological Diseases (ImaginEM) group	Siemens	Prisma-fit	HeadNeck_64	syngo_MR_E11	Martinez-Heras E, Solana E, Llufriu S	MildCompression	mild spinal cord compression due to C4/5 disc protrusion
+sub-002_ses-headNormal_T2w.nii.gz	train	F	22	0.6	N
+sub-003_ses-headNormal_T2w.nii.gz	train	M	22	0.6	N
+sub-003_ses-headUp_T2w.nii.gz	train	M	22	0.6	U
+sub-004_ses-headNormal_T2w.nii.gz	train	F	23	0.6	N
+sub-005_ses-headNormal_T2w.nii.gz	train	M	22	0.6	N
+sub-005_ses-headUp_T2w.nii.gz	train	M	22	0.6	U
+sub-007_ses-headUp_T2w.nii.gz	train	M	23	0.6	U
+sub-010_ses-headNormal_T2w.nii.gz	train	M	23	0.6	N
+sub-011_ses-headNormal_T2w.nii.gz	train	M	23	0.6	N
+sub-011_ses-headUp_T2w.nii.gz	train	M	23	0.6	U
+sub-007_ses-headNormal_T2w.nii.gz	test	M	23	0.6	N
+sub-010_ses-headUp_T2w.nii.gz	test	M	23	0.6	U

--- a/training/parse_nnunet_training_log.py
+++ b/training/parse_nnunet_training_log.py
@@ -1,0 +1,117 @@
+"""
+Read nnUNet training log file, extract epoch number and pseudo dice and plot them.
+This is useful for comparing multi-class training (because nnUNet plots only the mean dice across classes).
+
+Usage:
+    python parse_nnunet_training_log.py -i <path_to_log_file>
+
+Author: Jan Valosek
+"""
+
+import os
+import re
+import argparse
+
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import plotly.express as px
+
+
+def extract_epoch_and_dice(log_file_path):
+    """
+    Extract fold number and epoch and pseudo dice from the log file.
+    Args:
+        log_file_path: Path to the log file.
+    Returns:
+        epoch_and_dice_data: List of dictionaries with keys 'epoch' and 'pseudo_dice'.
+        fold_number: Fold number used for training.
+    """
+    fold_pattern = re.compile(r'Desired fold for training: (\d+)')
+    epoch_pattern = re.compile(r'Epoch (\d+)')
+    dice_pattern = re.compile(r'Pseudo dice \[([^,\]]+(?:, [^,\]]+)*)\]')
+
+    with open(log_file_path, 'r') as file:
+        lines = file.readlines()
+
+    epoch_and_dice_data = []
+    for line in lines:
+        fold_match = fold_pattern.search(line)
+        epoch_match = epoch_pattern.search(line)
+        dice_match = dice_pattern.search(line)
+
+        if fold_match:
+            fold_number = int(fold_match.group(1))
+
+        if epoch_match:
+            epoch = int(epoch_match.group(1))
+            epoch_and_dice_data.append({'epoch': epoch, 'pseudo_dice': None})
+
+        elif dice_match:
+            # Extracting the list using regular expression
+            list_match = re.search(r'\[.*\]', dice_match.group())
+
+            if list_match:
+                extracted_list_str = list_match.group(0)
+                # Replace 'nan' with the actual nan value
+                extracted_list_str = extracted_list_str.replace('nan', 'float("nan")')
+                # Evaluating the string representation of the list
+                extracted_list = eval(extracted_list_str)
+                epoch_and_dice_data[-1]['pseudo_dice'] = extracted_list
+
+    return epoch_and_dice_data, fold_number
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Extract Epoch number and Pseudo dice from a log file.')
+    parser.add_argument('-i', type=str, help='Path to the log file')
+
+    args = parser.parse_args()
+    # Get absolute path to the log file
+    log_file_path = os.path.abspath(os.path.expanduser(args.log_path))
+
+    data, fold_number = extract_epoch_and_dice(log_file_path)
+
+    # Convert data to a Pandas DataFrame
+    df = pd.DataFrame(data)
+
+    # Create columns for each element in pseudo_dice
+    # [:-1] is used to remove the last row, which is empty
+    df_pseudo_dice = pd.DataFrame(df['pseudo_dice'].to_list()[:-1],
+                                  columns=[f'pseudo_dice_{i+1}' for i in range(len(df['pseudo_dice'].iloc[0]))])
+
+    # Concatenate the new DataFrame with the original DataFrame
+    df = pd.concat([df, df_pseudo_dice], axis=1).drop('pseudo_dice', axis=1)
+
+    # Compute mean of pseudo dice across all classes
+    df['pseudo_dice_mean'] = df.iloc[:, 1:].mean(axis=1)
+
+    # Plotting using Plotly Express
+    fig = px.line(df, x='epoch', y=df.columns[1:], title='Pseudo Dice vs. Epoch')
+    # Update the line color for 'pseudo_dice_mean' to black
+    fig.update_traces(line=dict(color='black', width=3), selector=dict(name='pseudo_dice_mean'))
+    # Fix the y-axis range to be between 0 and 1
+    fig.update_yaxes(range=[-0.1, 1.1])
+    # Add y-axis title
+    fig.update_yaxes(title_text='Dice')
+    # Add title with fold number
+    fig.update_layout(title=f'Fold {fold_number} -- Pseudo Dice vs. Epoch (Training)')
+    #fig.show()
+    # Save plot to a file
+    fname_fig = log_file_path.replace('.txt', '.png')
+    fig.write_image(fname_fig, width=1920, height=1080)
+    print(f'Saved plot to {fname_fig}')
+
+    # Plotting using Seaborn
+    # sns.lineplot(data=df.drop('epoch', axis=1), dashes=True)
+    # plt.xlabel('Epoch')
+    # plt.ylabel('Pseudo Dice')
+    # plt.title('Pseudo Dice vs. Epoch')
+    # plt.show()
+    # plt.savefig('pseudo_dice_vs_epoch.png')
+    # plt.close()
+    # print('Saved plot to pseudo_dice_vs_epoch.png')
+
+
+if __name__ == "__main__":
+    main()

--- a/training/parse_nnunet_training_log.py
+++ b/training/parse_nnunet_training_log.py
@@ -96,7 +96,7 @@ def main():
     fig.update_yaxes(title_text='Dice')
     # Add title with fold number
     fig.update_layout(title=f'Fold {fold_number} -- Pseudo Dice vs. Epoch (Training)')
-    #fig.show()
+    fig.show()
     # Save plot to a file
     fname_fig = log_file_path.replace('.txt', '.png')
     fig.write_image(fname_fig, width=1920, height=1080)

--- a/training/parse_nnunet_training_log.py
+++ b/training/parse_nnunet_training_log.py
@@ -68,7 +68,7 @@ def main():
 
     args = parser.parse_args()
     # Get absolute path to the log file
-    log_file_path = os.path.abspath(os.path.expanduser(args.log_path))
+    log_file_path = os.path.abspath(os.path.expanduser(args.i))
 
     data, fold_number = extract_epoch_and_dice(log_file_path)
 

--- a/training/parse_nnunet_training_log.py
+++ b/training/parse_nnunet_training_log.py
@@ -104,6 +104,8 @@ def main():
 
     # Print the latest Dice for each class
     print(f'Latest Dice for each class: {df.iloc[-2, 1:-1].to_list()}')
+    # Print the mean Dice across all classes
+    print(f'Mean Dice across all classes: {df.iloc[-2, -1]}')
 
     # Plotting using Seaborn
     # sns.lineplot(data=df.drop('epoch', axis=1), dashes=True)

--- a/training/parse_nnunet_training_log.py
+++ b/training/parse_nnunet_training_log.py
@@ -102,6 +102,9 @@ def main():
     fig.write_image(fname_fig, width=1920, height=1080)
     print(f'Saved plot to {fname_fig}')
 
+    # Print the latest Dice for each class
+    print(f'Latest Dice for each class: {df.iloc[-2, 1:-1].to_list()}')
+
     # Plotting using Seaborn
     # sns.lineplot(data=df.drop('epoch', axis=1), dashes=True)
     # plt.xlabel('Epoch')


### PR DESCRIPTION
This PR adds dataset D4 and model M4.

## Dataset D4

- Five images used for [inter-rater variability](https://github.com/ivadomed/model-spinal-rootlets/issues/17) (`sub-007_ses-headNormal_T2w.nii.gz`, `sub-010_ses-headUp_T2w.nii.gz`, `sub-amu02_T2w.nii.gz`, `sub-barcelona01_T2w.nii.gz`, `sub-brnoUhb03_T2w.nii.gz`) were moved from the training dataset to the test dataset. The reason is that I want to apply model M4 on these five images and compare the M4 predictions with manual segmentations from 4 raters -- the images cannot be in the training set (the model would be biased).
- The D3 model was applied to five new randomly chosen images from the spine-generic dataset (`sub-mgh01_T2w.nii.gz`, `sub-mgh02_T2w.nii.gz`, `sub-stanford02_T2w.nii.gz`, `sub-stanford05_T2w.nii.gz`, `sub-ucdavis03_T2w.nii.gz`), the images were QCed, manually corrected and added to the training dataset. 
- The D4 training dataset comprises 33 images, and the test dataset comprises 5 images. For details, see [D4.tsv](https://github.com/ivadomed/model-spinal-rootlets/blob/jv/add_D4_and_M4/training/dataset_creation/D4.tsv).

## Model M4

- The dataset D4 is composed of 38 images with 33 for train.
- I am currently training 5 folds of a nnUNet 3d_fullres model for 2000 epochs: 

```
nnUNetv2_plan_and_preprocess -d 011 --verify_dataset_integrity -c 3d_fullres
CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 0 -tr nnUNetTrainer_2000epochs
CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 1 -tr nnUNetTrainer_2000epochs
CUDA_VISIBLE_DEVICES=3 nnUNetv2_train 011 3d_fullres 2 -tr nnUNetTrainer_2000epochs
CUDA_VISIBLE_DEVICES=1 nnUNetv2_train 011 3d_fullres 3 -tr nnUNetTrainer_2000epochs
CUDA_VISIBLE_DEVICES=2 nnUNetv2_train 011 3d_fullres 4 -tr nnUNetTrainer_2000epochs
```
