### PR TITLE
`README.md`: Add citation info for arxiv preprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Automatic Segmentation of Spinal Nerve Rootlets 
 
+[![arXiv](https://img.shields.io/badge/arXiv-2310.15402-b31b1b.svg)](https://doi.org/10.48550/arXiv.2402.00724)
+
 This repository contains the code for deep learning-based segmentation of the spinal nerve rootlets. 
 The code is based on the [nnUNet framework](https://github.com/MIC-DKFZ/nnUNet).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 This repository contains the code for deep learning-based segmentation of the spinal nerve rootlets. 
 The code is based on the [nnUNet framework](https://github.com/MIC-DKFZ/nnUNet).
 
+## Citation Info
+
+If you find this work and/or code useful for your research, please refer to the [following preprint](https://doi.org/10.48550/arXiv.2402.00724):
+
+```bibtex
+@misc{valosek2024automatic,
+      title={Automatic Segmentation of the Spinal Cord Nerve Rootlets}, 
+      author={Jan Valosek and Theo Mathieu and Raphaelle Schlienger and Olivia S. Kowalczyk and Julien Cohen-Adad},
+      year={2024},
+      eprint={2402.00724},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
 ## Model Overview
 
 The model was trained on T2-weighted images and provides semantic (i.e., level-specific) segmentation of the dorsal 
@@ -77,17 +92,3 @@ python packaging/run_inference_single_subject.py -i sub-001_T2w.nii.gz -o sub-00
 
 ℹ️ The script also supports getting segmentations on a GPU. To do so, simply add the flag `--use-gpu` at the end of the above commands. By default, the inference is run on the CPU. It is useful to note that obtaining the predictions from the GPU is significantly faster than the CPU.
 
-## Citation Info
-
-If you find this work and/or code useful for your research, please refer to the [following preprint](https://doi.org/10.48550/arXiv.2402.00724):
-
-```bibtex
-@misc{valosek2024automatic,
-      title={Automatic Segmentation of the Spinal Cord Nerve Rootlets}, 
-      author={Jan Valosek and Theo Mathieu and Raphaelle Schlienger and Olivia S. Kowalczyk and Julien Cohen-Adad},
-      year={2024},
-      eprint={2402.00724},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV}
-}
-```

--- a/README.md
+++ b/README.md
@@ -75,3 +75,17 @@ python packaging/run_inference_single_subject.py -i sub-001_T2w.nii.gz -o sub-00
 
 ℹ️ The script also supports getting segmentations on a GPU. To do so, simply add the flag `--use-gpu` at the end of the above commands. By default, the inference is run on the CPU. It is useful to note that obtaining the predictions from the GPU is significantly faster than the CPU.
 
+## Citation Info
+
+If you find this work and/or code useful for your research, please refer to the [following preprint](https://doi.org/10.48550/arXiv.2402.00724):
+
+```bibtex
+@misc{valosek2024automatic,
+      title={Automatic Segmentation of the Spinal Cord Nerve Rootlets}, 
+      author={Jan Valosek and Theo Mathieu and Raphaelle Schlienger and Olivia S. Kowalczyk and Julien Cohen-Adad},
+      year={2024},
+      eprint={2402.00724},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```


### PR DESCRIPTION
Adding this because I was looking for the preprint (to refer to in `sct_deepseg`'s long description), but couldn't find it in the readme, and had to go to Slack to see it.