### PR TITLE
Update README to MP2RAGE model and SCT v7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,48 @@ spinal nerve rootlets.
 
 ### Install dependencies
 
-- [Spinal Cord Toolbox (SCT) v6.2](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.2) or higher -- follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
+- [Spinal Cord Toolbox (SCT)]—follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
 - [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
 - Python
 
-Once the dependencies are installed, download the latest rootlets model:
+### Usage SCT [v7.0+](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/7.0)
+
+Once the dependencies are installed, download the latest rootlets model 
+([r20250318](https://github.com/ivadomed/model-spinal-rootlets/releases/tag/r20250318)—segmenting C2-T1 dorsal and 
+ventral rootlets from T2w and MP2RAGE images):
+
+```bash
+sct_deepseg rootlets -install
+```
+
+### Getting the rootlets segmentation
+
+To segment a single image, run the following command: 
+
+```bash
+sct_deepseg rootlets -i <INPUT> -o <OUTPUT>
+```
+
+For example:
+
+```bash
+sct_deepseg rootlets -i sub-001_T2w.nii.gz -o sub-001_T2w_label-rootlets_dseg.nii.gz
+```
+
+### Usage SCT [v6.2+](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.2)
+
+<details>
+<summary>Instructions for 6.2 (with old syntax)</summary>
+
+Once the dependencies are installed, download the rootlets model
+([r20240730](https://github.com/ivadomed/model-spinal-rootlets/releases/tag/r20240730)—segmenting C2-C8 dorsal 
+rootlets from T2w images):
 
 ```bash
 sct_deepseg -install-task seg_spinal_rootlets_t2w
 ```
 
-### Getting the rootlet segmentation
+### Getting the rootlets segmentation
 
 To segment a single image, run the following command: 
 
@@ -56,3 +87,5 @@ For example:
 ```bash
 sct_deepseg -i sub-001_T2w.nii.gz -o sub-001_T2w_label-rootlets_dseg.nii.gz -task seg_spinal_rootlets_t2w
 ```
+
+</details>

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ spinal nerve rootlets.
 ### Install dependencies
 
 - Spinal Cord Toolbox (SCT)—follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
-- [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
-- Python
 
 ### Usage SCT [v7.0+](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/7.0)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you find this work and/or code useful for your research, please cite the [fol
 ## Model Overview
 
 The model was trained on T2-weighted and MP2RAGE images and provides semantic (i.e., level-specific) segmentation of 
-the dorsal and ventral spinal nerve rootlets C2-T1.
+C2-T1 dorsal and ventral spinal nerve rootlets.
 
 ## How to use the model
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ventral rootlets from T2w and MP2RAGE images):
 sct_deepseg rootlets -install
 ```
 
-### Getting the rootlets segmentation
+### Getting the rootlet segmentation
 
 To segment a single image, run the following command: 
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If you find this work and/or code useful for your research, please cite the [fol
 
 ## Model Overview
 
-The model was trained on T2-weighted images and provides semantic (i.e., level-specific) segmentation of the dorsal 
-spinal nerve rootlets.
+The model was trained on T2-weighted and MP2RAGE images and provides semantic (i.e., level-specific) segmentation of 
+the dorsal and ventral spinal nerve rootlets C2-T1.
 
 ## How to use the model
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you find this work and/or code useful for your research, please cite the [fol
 
 ## Model Overview
 
-The model was trained on T2-weighted and MP2RAGE images and provides semantic (i.e., level-specific) segmentation of 
+The model was trained on T2-weighted and MP2RAGE (T1-weighted INV1 and INV2, and UNIT1) images and provides semantic (i.e., level-specific) segmentation of 
 C2-T1 dorsal and ventral spinal nerve rootlets.
 
 ## How to use the model

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ spinal nerve rootlets.
 
 ### Install dependencies
 
-- [Spinal Cord Toolbox (SCT)]—follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
+- Spinal Cord Toolbox (SCT)—follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
 - [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
 - Python
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ rootlets from T2w images):
 sct_deepseg -install-task seg_spinal_rootlets_t2w
 ```
 
-### Getting the rootlets segmentation
+### Getting the rootlet segmentation
 
 To segment a single image, run the following command: 
 


### PR DESCRIPTION
Update `README.md` to include:
- new syntax for SCT v7.0
- [r20250318](https://github.com/ivadomed/model-spinal-rootlets/releases/tag/r20250318) model segmenting C2-T1 dorsal and ventral rootlets from T2w and MP2RAGE images

Nicely rendered README for review: https://github.com/ivadomed/model-spinal-rootlets/blob/jv/update_readme_to_SCT_7.0/README.md